### PR TITLE
Fix ordering of unescaping logic, incl. tests

### DIFF
--- a/lib/append.spec.js
+++ b/lib/append.spec.js
@@ -3,17 +3,17 @@ const JsonPointer = require("./json-pointer");
 
 
 describe("append", () => {
-  it("should append a segment to a ponter", () => {
+  it("should append a segment to a pointer", () => {
     const subject = JsonPointer.append("bar", "/foo");
     expect(subject).to.eql("/foo/bar");
   });
 
-  it("should append a segment to the nil ponter", () => {
+  it("should append a segment to the nil pointer", () => {
     const subject = JsonPointer.append("bar", JsonPointer.nil);
     expect(subject).to.eql("/bar");
   });
 
-  it("should escape an segment when it is appended to a ponter", () => {
+  it("should escape a segment when it is appended to a pointer", () => {
     const subject = JsonPointer.append("b~a/r", "/foo");
     expect(subject).to.eql("/foo/b~0a~1r");
   });

--- a/lib/get.spec.js
+++ b/lib/get.spec.js
@@ -14,6 +14,10 @@ describe("JsonPointer", () => {
     "k\"l": 6,
     " ": 7,
     "m~n": 8,
+    "~0": 9,
+    "~1": 10,
+    "/0": 11,
+    "/1": 12,
     "aaa": null
   };
 
@@ -30,7 +34,11 @@ describe("JsonPointer", () => {
       ["/i\\j", 5],
       ["/k\"l", 6],
       ["/ ", 7],
-      ["/m~0n", 8]
+      ["/m~0n", 8],
+      ["/~00", 9],
+      ["/~01", 10],
+      ["/~10", 11],
+      ["/~11", 12]
     ].forEach(([pointer, expected]) => {
       describe(JSON.stringify(pointer), () => {
         let ptr;

--- a/lib/get.spec.js
+++ b/lib/get.spec.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const JsonPointer = require("./json-pointer");
 
 
-describe("JsonPonter", () => {
+describe("JsonPointer", () => {
   const subject = {
     "foo": ["bar", "baz"],
     "": 0,

--- a/lib/json-pointer.js
+++ b/lib/json-pointer.js
@@ -110,7 +110,7 @@ const _remove = (pointer, subject, cursor) => {
 const append = curry((segment, pointer) => pointer + "/" + escape(segment));
 
 const escape = (segment) => segment.toString().replace(/~/g, "~0").replace(/\//g, "~1");
-const unescape = (segment) => segment.toString().replace(/~0/g, "~").replace(/~1/g, "/");
+const unescape = (segment) => segment.toString().replace(/~1/g, "/").replace(/~0/g, "~");
 
 const applySegment = (value, segment, cursor = "") => {
   if (isScalar(value)) {


### PR DESCRIPTION
This PR fixes a bug in the `unescape` function where the action of the `escape` function is not correctly reversed, because the substitutions are done in an unstable order. Tests are added.

A separate commit tidies up a couple of typos in the tests.