### PR TITLE
Array element - (dash) syntax support

### DIFF
--- a/lib/assign.spec.js
+++ b/lib/assign.spec.js
@@ -57,10 +57,16 @@ describe("JsonPointer.assign", () => {
   });
 
   Given("an object", () => {
-    const subject = { aaa: { bbb: {} } };
+    let subject;
+
+    beforeEach(() => {
+      subject = { aaa: { bbb: {} } };
+    });
 
     When("mutating a value that doesn't exist", () => {
-      JsonPointer.assign("/bbb", subject, "foo");
+      beforeEach(() => {
+        JsonPointer.assign("/bbb", subject, "foo");
+      });
 
       Then("the value should be set", () => {
         expect(subject.bbb).to.equal("foo");
@@ -77,10 +83,16 @@ describe("JsonPointer.assign", () => {
   });
 
   Given("an array", () => {
-    const subject = [];
+    let subject;
+
+    beforeEach(() => {
+      subject = [];
+    });
 
     When("mutating a value that doesn't exist", () => {
-      JsonPointer.assign("/0", subject, "foo");
+      beforeEach(() => {
+        JsonPointer.assign("/0", subject, "foo");
+      });
 
       Then("the value should be set", () => {
         expect(subject[0]).to.equal("foo");
@@ -89,7 +101,11 @@ describe("JsonPointer.assign", () => {
   });
 
   Given("a number", () => {
-    const subject = 42;
+    let subject;
+
+    beforeEach(() => {
+      subject = 42;
+    });
 
     When("indexing into the number", () => {
       const assign = JsonPointer.assign("/0");
@@ -101,7 +117,11 @@ describe("JsonPointer.assign", () => {
   });
 
   Given("a string", () => {
-    const subject = "foo";
+    let subject;
+
+    beforeEach(() => {
+      subject = "foo";
+    });
 
     When("indexing into the string", () => {
       const assign = JsonPointer.assign("/0");
@@ -113,7 +133,11 @@ describe("JsonPointer.assign", () => {
   });
 
   Given("null", () => {
-    const subject = null;
+    let subject;
+
+    beforeEach(() => {
+      subject = null;
+    });
 
     When("indexing into null", () => {
       const assign = JsonPointer.assign("/0");

--- a/lib/assign.spec.js
+++ b/lib/assign.spec.js
@@ -98,6 +98,16 @@ describe("JsonPointer.assign", () => {
         expect(subject[0]).to.equal("foo");
       });
     });
+
+    When("adding an item to the end of the array", () => {
+      beforeEach(() => {
+        JsonPointer.assign("/-", subject, "foo");
+      });
+
+      Then("the value should be set", () => {
+        expect(subject[0]).to.equal("foo");
+      });
+    });
   });
 
   Given("a number", () => {

--- a/lib/delete.spec.js
+++ b/lib/delete.spec.js
@@ -98,6 +98,16 @@ describe("JsonPointer.delete", () => {
         expect(subject).to.eql([]);
       });
     });
+
+    When("deleting past the end of the array", () => {
+      beforeEach(() => {
+        JsonPointer.delete("/-", subject, "foo");
+      });
+
+      Then("the value should be unchanged", () => {
+        expect(subject).to.eql([]);
+      });
+    });
   });
 
   Given("a number", () => {

--- a/lib/delete.spec.js
+++ b/lib/delete.spec.js
@@ -57,10 +57,16 @@ describe("JsonPointer.delete", () => {
   });
 
   Given("an object", () => {
-    const subject = { aaa: { bbb: {} } };
+    let subject;
+
+    beforeEach(() => {
+      subject = { aaa: { bbb: {} } };
+    });
 
     When("deleting a value that doesn't exist", () => {
-      JsonPointer.delete("/bbb", subject);
+      beforeEach(() => {
+        JsonPointer.delete("/bbb", subject);
+      });
 
       Then("the value should be unchanged", () => {
         expect(subject).to.eql({ aaa: { bbb: {} } });
@@ -77,10 +83,16 @@ describe("JsonPointer.delete", () => {
   });
 
   Given("an array", () => {
-    const subject = [];
+    let subject;
+
+    beforeEach(() => {
+      subject = [];
+    });
 
     When("deleting a value that doesn't exist", () => {
-      JsonPointer.delete("/0", subject, "foo");
+      beforeEach(() => {
+        JsonPointer.delete("/0", subject, "foo");
+      });
 
       Then("the value should be unchanged", () => {
         expect(subject).to.eql([]);
@@ -89,7 +101,11 @@ describe("JsonPointer.delete", () => {
   });
 
   Given("a number", () => {
-    const subject = 42;
+    let subject;
+
+    beforeEach(() => {
+      subject = 42;
+    });
 
     When("indexing into the number", () => {
       const remove = JsonPointer.delete("/0");
@@ -101,7 +117,11 @@ describe("JsonPointer.delete", () => {
   });
 
   Given("a string", () => {
-    const subject = "foo";
+    let subject;
+
+    beforeEach(() => {
+      subject = "foo";
+    });
 
     When("indexing into the string", () => {
       const remove = JsonPointer.delete("/0");
@@ -113,7 +133,11 @@ describe("JsonPointer.delete", () => {
   });
 
   Given("null", () => {
-    const subject = null;
+    let subject;
+
+    beforeEach(() => {
+      subject = null;
+    });
 
     When("indexing into null", () => {
       const remove = JsonPointer.delete("/0");

--- a/lib/get.spec.js
+++ b/lib/get.spec.js
@@ -18,7 +18,8 @@ describe("JsonPointer", () => {
     "~1": 10,
     "/0": 11,
     "/1": 12,
-    "aaa": null
+    "aaa": null,
+    "bbb": { "-": { "ccc": 13 } }
   };
 
   describe("get", () => {
@@ -38,7 +39,9 @@ describe("JsonPointer", () => {
       ["/~00", 9],
       ["/~01", 10],
       ["/~10", 11],
-      ["/~11", 12]
+      ["/~11", 12],
+      ["/bbb/-/ccc", 13],
+      ["/bbb/-", { "ccc": 13 }]
     ].forEach(([pointer, expected]) => {
       describe(JSON.stringify(pointer), () => {
         let ptr;

--- a/lib/get.spec.js
+++ b/lib/get.spec.js
@@ -68,6 +68,13 @@ describe("JsonPointer", () => {
     });
   });
 
+  describe("pointing to the end of an array", () => {
+    it("should throw an error", () => {
+      const ptr = JsonPointer.get("/foo/-");
+      expect(() => ptr(subject)).to.throw(Error, "Value at '/foo' does not have index '2'");
+    });
+  });
+
   describe("indexing into a scalar", () => {
     it("should throw an error", () => {
       const ptr = JsonPointer.get("//foo");

--- a/lib/json-pointer.js
+++ b/lib/json-pointer.js
@@ -34,8 +34,9 @@ const _set = (pointer, subject, value, cursor) => {
     const segment = pointer.shift();
     return { ...subject, [segment]: _set(pointer, applySegment(subject, segment, cursor), value, append(segment, cursor)) };
   } else if (Array.isArray(subject)) {
-    const clonedSubject = { ...subject };
-    clonedSubject[pointer[0]] = value;
+    const clonedSubject = [ ...subject ];
+    const segment = computeSegment(subject, pointer[0]);
+    clonedSubject[segment] = value;
     return clonedSubject;
   } else if (typeof subject === "object" && subject !== null) {
     return { ...subject, [pointer[0]]: value };
@@ -54,7 +55,7 @@ const _assign = (pointer, subject, value, cursor) => {
   if (pointer.length === 0) {
     return;
   } else if (pointer.length === 1 && !isScalar(subject)) {
-    const segment = pointer[0];
+    const segment = computeSegment(subject, pointer[0]);
     subject[segment] = value;
   } else {
     const segment = pointer.shift();
@@ -111,12 +112,16 @@ const append = curry((segment, pointer) => pointer + "/" + escape(segment));
 
 const escape = (segment) => segment.toString().replace(/~/g, "~0").replace(/\//g, "~1");
 const unescape = (segment) => segment.toString().replace(/~1/g, "/").replace(/~0/g, "~");
+const computeSegment = (value, segment) => Array.isArray(value) && segment === "-" ? value.length : segment;
 
 const applySegment = (value, segment, cursor = "") => {
   if (isScalar(value)) {
     throw Error(`Value at '${cursor}' is a scalar and can't be indexed`);
-  } else if (!(segment in value)) {
-    throw Error(`Value at '${cursor}' does not have index '${segment}'`);
+  }
+
+  const computedSegment = computeSegment(value, segment);
+  if (!(computedSegment in value)) {
+    throw Error(`Value at '${cursor}' does not have index '${computedSegment}'`);
   }
 
   return value[segment];

--- a/lib/json-pointer.js
+++ b/lib/json-pointer.js
@@ -34,7 +34,7 @@ const _set = (pointer, subject, value, cursor) => {
     const segment = pointer.shift();
     return { ...subject, [segment]: _set(pointer, applySegment(subject, segment, cursor), value, append(segment, cursor)) };
   } else if (Array.isArray(subject)) {
-    const clonedSubject = [ ...subject ];
+    const clonedSubject = [...subject];
     const segment = computeSegment(subject, pointer[0]);
     clonedSubject[segment] = value;
     return clonedSubject;
@@ -79,6 +79,7 @@ const _unset = (pointer, subject, cursor) => {
   } else if (Array.isArray(subject)) {
     return subject.filter((_, ndx) => ndx != pointer[0]);
   } else if (typeof subject === "object" && subject !== null) {
+    // eslint-disable-next-line no-unused-vars
     const { [pointer[0]]: _, ...result } = subject;
     return result;
   } else {
@@ -124,7 +125,7 @@ const applySegment = (value, segment, cursor = "") => {
     throw Error(`Value at '${cursor}' does not have index '${computedSegment}'`);
   }
 
-  return value[segment];
+  return value[computedSegment];
 };
 
 const isScalar = (value) => value === null || typeof value !== "object";

--- a/lib/set.spec.js
+++ b/lib/set.spec.js
@@ -86,10 +86,18 @@ describe("JsonPointer.set", () => {
   });
 
   Given("an object", () => {
-    const subject = { aaa: { bbb: {} } };
+    let subject;
+
+    beforeEach(() => {
+      subject = { aaa: { bbb: {} } };
+    });
 
     When("setting a value that doesn't exist", () => {
-      const result = JsonPointer.set("/bbb", subject, "foo");
+      let result;
+
+      beforeEach(() => {
+        result = JsonPointer.set("/bbb", subject, "foo");
+      });
 
       Then("the value should be set", () => {
         expect(result.bbb).to.equal("foo");
@@ -110,10 +118,18 @@ describe("JsonPointer.set", () => {
   });
 
   Given("an array", () => {
-    const subject = [];
+    let subject;
+
+    beforeEach(() => {
+      subject = [];
+    });
 
     When("setting a value that doesn't exist", () => {
-      const result = JsonPointer.set("/0", subject, "foo");
+      let result;
+
+      beforeEach(() => {
+        result = JsonPointer.set("/0", subject, "foo");
+      });
 
       Then("the value should be set", () => {
         expect(result[0]).to.equal("foo");
@@ -126,7 +142,11 @@ describe("JsonPointer.set", () => {
   });
 
   Given("a number", () => {
-    const subject = 42;
+    let subject;
+
+    beforeEach(() => {
+      subject = 42;
+    });
 
     When("indexing into the number", () => {
       const set = JsonPointer.set("/0");
@@ -138,7 +158,11 @@ describe("JsonPointer.set", () => {
   });
 
   Given("a string", () => {
-    const subject = "foo";
+    let subject;
+
+    beforeEach(() => {
+      subject = "foo";
+    });
 
     When("indexing into the string", () => {
       const set = JsonPointer.set("/0");
@@ -150,7 +174,11 @@ describe("JsonPointer.set", () => {
   });
 
   Given("null", () => {
-    const subject = null;
+    let subject;
+
+    beforeEach(() => {
+      subject = null;
+    });
 
     When("indexing into null", () => {
       const set = JsonPointer.set("/0");

--- a/lib/set.spec.js
+++ b/lib/set.spec.js
@@ -139,6 +139,22 @@ describe("JsonPointer.set", () => {
         expect(subject[0]).to.equal(undefined);
       });
     });
+
+    When("adding an item to the end of the array", () => {
+      let result;
+
+      beforeEach(() => {
+        result = JsonPointer.set("/-", subject, "foo");
+      });
+
+      Then("the value should be set", () => {
+        expect(result[0]).to.equal("foo");
+      });
+
+      Then("the original value should not change", () => {
+        expect(subject[0]).to.equal(undefined);
+      });
+    });
   });
 
   Given("a number", () => {

--- a/lib/unset.spec.js
+++ b/lib/unset.spec.js
@@ -133,6 +133,18 @@ describe("JsonPointer.unset", () => {
         expect(result).to.eql(subject);
       });
     });
+
+    When("deleting past the end of the array", () => {
+      let result;
+
+      beforeEach(() => {
+        result = JsonPointer.unset("/-", subject);
+      });
+
+      Then("the original value should not change", () => {
+        expect(result).to.eql(subject);
+      });
+    });
   });
 
   Given("a number", () => {

--- a/lib/unset.spec.js
+++ b/lib/unset.spec.js
@@ -86,10 +86,17 @@ describe("JsonPointer.unset", () => {
   });
 
   Given("an object", () => {
-    const subject = { aaa: { bbb: {} } };
+    let subject;
+
+    beforeEach(() => {
+      subject = { aaa: { bbb: {} } };
+    });
 
     When("deleting a value that doesn't exist", () => {
-      const result = JsonPointer.unset("/bbb", subject);
+      let result;
+      beforeEach(() => {
+        result = JsonPointer.unset("/bbb", subject);
+      });
 
       Then("the value should be undefined", () => {
         expect(result.bbb).to.equal(undefined);
@@ -110,23 +117,30 @@ describe("JsonPointer.unset", () => {
   });
 
   Given("an array", () => {
-    const subject = [];
+    let subject;
+
+    beforeEach(() => {
+      subject = [];
+    });
 
     When("deleting a value that doesn't exist", () => {
-      const result = JsonPointer.unset("/0", subject);
-
-      Then("the value should be removed", () => {
-        expect(result).to.eql([]);
+      let result;
+      beforeEach(() => {
+        result = JsonPointer.unset("/0", subject);
       });
 
       Then("the original value should not change", () => {
-        expect(subject).to.eql([]);
+        expect(result).to.eql(subject);
       });
     });
   });
 
   Given("a number", () => {
-    const subject = 42;
+    let subject;
+
+    beforeEach(() => {
+      subject = 42;
+    });
 
     When("indexing into the number", () => {
       const unset = JsonPointer.unset("/0");
@@ -138,7 +152,11 @@ describe("JsonPointer.unset", () => {
   });
 
   Given("a string", () => {
-    const subject = "foo";
+    let subject;
+
+    beforeEach(() => {
+      subject = "foo";
+    });
 
     When("indexing into the string", () => {
       const unset = JsonPointer.unset("/0");
@@ -150,7 +168,11 @@ describe("JsonPointer.unset", () => {
   });
 
   Given("null", () => {
-    const subject = null;
+    let subject;
+
+    beforeEach(() => {
+      subject = null;
+    });
 
     When("indexing into null", () => {
       const unset = JsonPointer.unset("/0");


### PR DESCRIPTION
#3  This bit of the spec was overlooked an hadn't been implemented yet.

>    o If the currently referenced value is a JSON array, the reference
>    token MUST contain either:
>    * characters comprised of digits (see ABNF below; note that
>    leading zeros are not allowed) that represent an unsigned
>    base-10 integer value, making the new referenced value the
>    array element with the zero-based index identified by the
>    token, or
>    * exactly the single character "-", making the new referenced
>    value the (nonexistent) member after the last array element.

@MikeRalphson I don't know if you got to this at all, but I ended up taking a stab at it. Let me know if you have any feedback.